### PR TITLE
Add Exception::Base::format to sprintf adoubles.

### DIFF
--- a/SimTKcommon/Mechanics/include/SimTKcommon/internal/MassProperties.h
+++ b/SimTKcommon/Mechanics/include/SimTKcommon/internal/MassProperties.h
@@ -531,8 +531,7 @@ void errChk(const char* methodName) const {
 
     SimTK_ERRCHK3(d >= -SignificantReal, methodName,
         "Diagonals of an Inertia matrix must be nonnegative; got %g,%g,%g.",
-        NTraits<P>::cast<double>(Ixx),NTraits<P>::cast<double>(Iyy),
-        NTraits<P>::cast<double>(Izz));
+        Ixx,Iyy,Izz);
 
     // TODO: This is looser than it should be as a workaround for distorted
     // rotation matrices that were produced by an 11,000 body chain that
@@ -545,9 +544,7 @@ void errChk(const char* methodName) const {
                   && Iyy+Izz+Slop>=Ixx,
         methodName,
         "Diagonals of an Inertia matrix must satisfy the triangle "
-        "inequality; got %g,%g,%g.",
-        NTraits<P>::cast<double>(Ixx),NTraits<P>::cast<double>(Iyy),
-        NTraits<P>::cast<double>(Izz));
+        "inequality; got %g,%g,%g.",Ixx,Iyy,Izz);
 
     // Thanks to Paul Mitiguy for this condition on products of inertia.
     SimTK_ERRCHK(   Ixx+Slop>=NTraits<P>::abs(2*Iyz) 
@@ -1013,7 +1010,7 @@ SpatialInertia_(RealP mass, const Vec3P& com, const UnitInertiaP& gyration)
 
 SpatialInertia_& setMass(RealP mass)
 {   SimTK_ERRCHK1(mass >= 0, "SpatialInertia::setMass()",
-        "Negative mass %g is illegal.", NTraits<RealP>::cast<double>(mass));
+        "Negative mass %g is illegal.", mass);
     m=mass; return *this; }
 SpatialInertia_& setMassCenter(const Vec3P& com)
 {   p=com; return *this;} 

--- a/SimTKcommon/include/SimTKcommon/internal/Exception.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Exception.h
@@ -58,6 +58,36 @@ protected:
         text = msgin;
         msg = "SimTK Exception thrown at " + where() + ":\n  " + msgin;
     }
+    
+    /// @name Support use of ADOL-C's adouble type with sprintf.
+    /// These templates are specialized for adouble (and perhaps other types).
+    /// @{
+    /// The return type for convertToPrintable()
+    template <typename T>
+    struct ReturnConvertToPrintable { typedef T type; };
+    /// Generic template that simply returns the passed-in argument.
+    template <typename T>
+    static typename ReturnConvertToPrintable<T>::type
+    convertToPrintable(const T& v) { return v; }
+    /// @}
+    
+    /// Format a string in the style of sprintf.
+    static std::string format(const char* format, ...) {
+        // Compute buffer size.
+        va_list args;
+        va_start(args, format);
+        int bufsize = vsnprintf(nullptr, 0, format, args) + 1; // +1 for '\0'
+        va_end(args);
+        
+        // Create formatted string.
+        std::unique_ptr<char[]> buf(new char[bufsize]);
+        va_start(args, format);
+        // Use the safe version of vsprintf.
+        vsnprintf(buf.get(), bufsize, format, args);
+        va_end(args);
+        return std::string(buf.get());
+    }
+
 private:
     std::string    fileName;    // where the exception was thrown
     int            lineNo;    
@@ -74,8 +104,26 @@ private:
         char buf[32];
         sprintf(buf,"%d",lineNo);
         return shortenFileName(fileName) + ":" + std::string(buf); 
-    } 
+    }
 };
+
+/// Specialization for std::string.
+template <> struct Base::ReturnConvertToPrintable<std::string>
+{   typedef const char* type; };
+template <>
+inline typename Base::ReturnConvertToPrintable<std::string>::type
+Base::convertToPrintable(const std::string& v) { return v.c_str(); }
+
+/// Specialization for ADOL-C's adouble.
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <> struct Base::ReturnConvertToPrintable<adouble>
+    { typedef double type; };
+    /// This function is not safe to use when taping, but because the function
+    /// is protected, the value is not likely to be used in any computations.
+    template <> inline Base::ReturnConvertToPrintable<adouble>::type
+    Base::convertToPrintable(const adouble& v)
+    { return v.value(); }
+#endif
 
 /// This is for reporting internally-detected bugs only, not problems induced by 
 /// confused users (that is, it is for confused developers instead). The exception
@@ -85,19 +133,16 @@ private:
 /// SimTK_ASSERT_ALWAYS macros.
 class Assert : public Base {
 public:
+    template <typename ...Types>
     Assert(const char* fn, int ln, const char* assertion, 
-             const char* fmt ...) : Base(fn,ln)
+             const char* fmt, Types... args) : Base(fn,ln)
     {
-        char buf[1024];
-        va_list args;
-        va_start(args, fmt);
-        vsprintf(buf, fmt, args);
+        std::string msg = format(fmt, convertToPrintable(args)...);
 
-        setMessage("Internal bug detected: " + std::string(buf)
+        setMessage("Internal bug detected: " + msg
                    + "\n  (Assertion '" + std::string(assertion) + "' failed).\n"
             "  Please file an Issue at https://github.com/simbody/simbody/issues.\n"
             "  Include the above information and anything else needed to reproduce the problem.");
-        va_end(args);
     }
     virtual ~Assert() throw() { }
 };
@@ -112,20 +157,16 @@ public:
 /// directly; use one of the family SimTK_ERRCHK and SimTK_ERRCHK_ALWAYS macros.
 class ErrorCheck : public Base {
 public:
+    template <typename ...Types>
     ErrorCheck(const char* fn, int ln, const char* assertion, 
            const char* whereChecked,    // e.g., ClassName::methodName()
-           const char* fmt ...) : Base(fn,ln)
+           const char* fmt, Types... args) : Base(fn,ln)
     {
-        char buf[1024];
-        va_list args;
-        va_start(args, fmt);
-        vsprintf(buf, fmt, args);
-
+        std::string msg = format(fmt, convertToPrintable(args)...);
         setMessage("Error detected by Simbody method " 
             + std::string(whereChecked) + ": "
-            + std::string(buf)
+            + msg
             + "\n  (Required condition '" + std::string(assertion) + "' was not met.)\n");
-        va_end(args);
     }
     virtual ~ErrorCheck() throw() { }
 };
@@ -139,19 +180,16 @@ public:
 /// SimTK_APIARGCHECK_ALWAYS macros.
 class APIArgcheckFailed : public Base {
 public:
+    template <typename ...Types>
     APIArgcheckFailed(const char* fn, int ln, const char* assertion,
                       const char* className, const char* methodName,
-                      const char* fmt ...) : Base(fn,ln)
+                      const char* fmt, Types... args) : Base(fn,ln)
     {
-        char buf[1024];
-        va_list args;
-        va_start(args, fmt);
-        vsprintf(buf, fmt, args);
+        std::string msg = format(fmt, convertToPrintable(args)...);
         setMessage("Bad call to Simbody API method " 
                    + std::string(className) + "::" + std::string(methodName) + "(): "
-                   + std::string(buf)
+                   + msg
                    + "\n  (Required condition '" + std::string(assertion) + "' was not met.)");
-        va_end(args);
     }
     virtual ~APIArgcheckFailed() throw() { }
 };


### PR DESCRIPTION
@antoinefalisse this PR avoids the need to use `NTraits::cast` when using the exception macros.

I did not test that the exception messages are still printed properly.