### PR TITLE
Fix MatrixHelper allocateMemory() for adouble (hack!)

### DIFF
--- a/SimTKcommon/include/SimTKcommon/Testing.h
+++ b/SimTKcommon/include/SimTKcommon/Testing.h
@@ -190,7 +190,7 @@ public:
         static double defTol(typename std::enable_if<
         std::is_same<typename CNT<T>::Precision, adouble>::value>::type* = 0)
         { return NTraits<typename CNT<adouble>::Precision>::
-            getSignificant().value(); }
+            getSignificant(); }
         template <class T>
         static double defTol(typename std::enable_if<
         !std::is_same<typename CNT<T>::Precision, adouble>::value>::type* = 0)


### PR DESCRIPTION
This PR is a hack to get `Vector` to work with `adouble.

See discussion here: https://github.com/antoinefalisse/simbody/commit/a48932dfc90d168d5b3ce0616f59b9fb98f7d4a5#commitcomment-28409788