### PR TITLE
add tests for offset and normal

### DIFF
--- a/Simbody/tests/TestHuntCrossleyForce_smooth.cpp
+++ b/Simbody/tests/TestHuntCrossleyForce_smooth.cpp
@@ -71,7 +71,8 @@ void testForces() {
     hc_smooth.setRadiusSphere(radius);
     State state = system.realizeTopology();
 
-    // Position the sphere at a variety of positions and check the normal force.
+    // Position the sphere at a variety of positions and check the normal force 
+    // (with an horizontal ground plane)
     for (Real height = radius+0.2; height > 0; height -= 0.1) {
         sphere.setQToFitTranslation(state, Vec3(0, height, 0));
         system.realize(state, Stage::Dynamics);
@@ -84,7 +85,7 @@ void testForces() {
     }
 
     // Now do it with a vertical velocity and see if the dissipation force is
-	// correct.
+	// correct (with an horizontal ground plane)
 
     for (Real height = radius+0.2; height > 0; height -= 0.1) {
         sphere.setQToFitTranslation(state, Vec3(0, height, 0));
@@ -106,7 +107,7 @@ void testForces() {
     }
 
     // Do it with a horizontal velocity and see if the friction force is 
-	// correct.
+	// correct (with an horizontal ground plane)
 
     Vector_<SpatialVec> expectedForce(matter.getNumBodies());
     for (Real height = radius+0.2; height > 0; height -= 0.1) {
@@ -143,6 +144,68 @@ void testForces() {
 				expectedForce[sphere.getMobilizedBodyIndex()][1]);
         }
     }
+
+    // Do it with different ground directions and offsets
+    Vector_<SpatialVec> expectedForce2(matter.getNumBodies());
+    
+    for (int i = 0; i < 20; i++) {
+        for (Real offset = -0.1; offset <= 0.1; offset += 0.01) {
+            Vec3 normal_rand((double)(rand() % 100 - 50)  / RAND_MAX, 
+                (double)(rand() % 100 - 50) / RAND_MAX, 
+                (double)(rand() % 100 - 50) / RAND_MAX);
+            normal_rand = normal_rand / normal_rand.norm();
+            hc_smooth.setGroundPlane(normal_rand, offset);
+            Vec3 loc_inG(0.23, 0.10, 0.42); // random location of the sphere in 
+            // the space, in Ground frame
+            sphere.setQToFitTranslation(state, loc_inG);
+            Vec3 vel_inG(0.34, -0.65, -0.48); // random velocity of the sphere 
+            // in the space, in Ground frame
+            sphere.setUToFitLinearVelocity(state, vel_inG);
+            system.realize(state, Stage::Dynamics);
+
+            Vec3 contactPoint = loc_inG - normal_rand*radius;
+            const Real depth = -(dot(contactPoint,normal_rand)-offset);
+            Real vnormal = dot(vel_inG, normal_rand);
+            Vec3 vtangent = vel_inG - vnormal*normal_rand;
+            Real IndentationVel = -vnormal;
+
+            Real fh = (4. / 3.)*stiffness1*
+                std::pow(std::sqrt(depth*depth + eps), 3. / 2.)*
+                std::sqrt(radius*stiffness1);
+            Real fhd = fh*(1. + (3. / 2.)*dissipation1*IndentationVel);
+            Real fh_smooth = fhd*(1. / 2. + (1. / 2.)*std::tanh(bd*depth))*
+                (1. / 2. + (1. / 2.)*std::tanh(bv*(IndentationVel + 
+                (2./(3.*dissipation1)))));;
+
+            Real aux = pow(vtangent[0], 2) + pow(vtangent[1], 2) +
+                pow(vtangent[2], 2) + eps;
+            Real vslip = pow(aux, 1. / 2.);
+            Real vrel = vslip / vt;
+            Real ff_smooth_scalar = fh_smooth*(std::min(vrel, Real(1))*
+                (ud1 + 2 * (us1 - ud1) / (1 + vrel*vrel)) + uv1*vslip);
+            Vec3 ff_smooth = ff_smooth_scalar*(-vtangent) / vslip;
+            const Vec3 totalForce = ff_smooth + fh_smooth*normal_rand;
+            expectedForce = SpatialVec(Vec3(0), Vec3(0));
+            expectedForce2 = SpatialVec(Vec3(0), Vec3(0));
+
+            Vec3 contactPointInSphere = -normal_rand*radius +
+                normal_rand*depth*(stiffness1 / (stiffness1 + stiffness1));
+            sphere.applyForceToBodyPoint(state, contactPointInSphere,
+                totalForce, expectedForce);
+            sphere.applyForceToBodyPoint(state, Vec3(0,0,0),
+                gravity, expectedForce2);
+            expectedForce = expectedForce + expectedForce2;
+            
+            SpatialVec actualForce(0);
+            actualForce = system.getRigidBodyForces(state,
+                Stage::Dynamics)[sphere.getMobilizedBodyIndex()];
+            assertEqual(actualForce[0],
+                expectedForce[sphere.getMobilizedBodyIndex()][0]);
+            assertEqual(actualForce[1],
+                expectedForce[sphere.getMobilizedBodyIndex()][1]);
+        }
+    }
+
 }
 
 int main() {


### PR DESCRIPTION
The test is for 20 random values of directions and with offsets from -0.1 to 0.1 (with steps of 0.01), for a certain radius, and position and velocity of the sphere.

By the way, the offset of the plane is not the height that this would have at the origin. I understand it as: a plane with an offset = 0 and a certain normal, it will cross the origin, and it will have a certain slope. Then, if we add an offset, we are moving along the normal of the plane (offset has a dimension of length).